### PR TITLE
handle relative symlink targets in normalizePath

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,7 +131,11 @@ func normalizePath(path string) string {
 		base := filepath.Base(path)
 
 		if target, err := os.Readlink(dir); err == nil {
-			dir = target
+			if filepath.IsAbs(target) {
+				dir = target
+			} else {
+				dir = filepath.Join(filepath.Dir(dir), target)
+			}
 		}
 
 		resolvedPath := filepath.Join(dir, base)


### PR DESCRIPTION
Resolve relative paths from Readlink relative to the parent directory of the symlink, not as-is.